### PR TITLE
Adds pop tip to confirm highlight.

### DIFF
--- a/vendor/assets/javascripts/content_highlight.js
+++ b/vendor/assets/javascripts/content_highlight.js
@@ -76,15 +76,15 @@ var contentHighlightWorker = function(element, options){
     var selection = rangy.getSelection();
     if (selection.isCollapsed == false && selection.rangeCount > 0) {
       event.stopPropagation();
-      var classApplier = rangy.createClassApplier('temp-selection');
-      classApplier.applyToSelection();
-      var selectionElement = element.getElementsByClassName('temp-selection')[0];
       if (!!self.popTip) {
         if (event.target.classList.contains('poptip-action')) {
           return;
         }
         self.removePopTip();
       }
+      var classApplier = rangy.createClassApplier('temp-selection');
+      classApplier.applyToSelection();
+      var selectionElement = element.getElementsByClassName('temp-selection')[0];
       self.buildPopupFromSelection();
       self.popTip.style.top = selectionElement.offsetTop + selectionElement.offsetHeight + "px";
       self.popTip.style.left = selectionElement.offsetLeft + 10 + "px";
@@ -102,8 +102,8 @@ var contentHighlightWorker = function(element, options){
     self.popTip.className = self.settings.popTipClass;
     self.popTip.innerHTML = "<a href='javascript:void(0);' class='poptip-action'>Add Highlight</a>";
     self.popTip.getElementsByClassName('poptip-action')[0].addEventListener('click', function(){
-      self.removePopTip();
       self.initializeHighlighter();
+      self.removePopTip();
     });
   }
 
@@ -113,9 +113,10 @@ var contentHighlightWorker = function(element, options){
     if(selection.isCollapsed == false && selection.rangeCount > 0){
       range = selection.getRangeAt(0);
       commonAncestor = range.commonAncestorContainer;
+      var element = this.element || this;
       while(commonAncestor.dataset == undefined || commonAncestor.dataset[self.settings.nodeIdentifierKey] == undefined){
         commonAncestor = commonAncestor.parentNode;
-        if(commonAncestor == undefined || commonAncestor.contains(this)){
+        if(commonAncestor == undefined || commonAncestor.contains(element)){
           return;
         }
       }

--- a/vendor/assets/javascripts/content_highlight.js
+++ b/vendor/assets/javascripts/content_highlight.js
@@ -42,6 +42,7 @@ var contentHighlightWorker = function(element, options){
     highlightableId: options.highlightableId || "",
     highlightableColumn: options.highlightableColumn || "",
     readOnly: options.readOnly || false,
+    confirmHighlight: options.confirmHighlight || false,
     nodeIdentifierKey: options.nodeIdentifierKey || "chnode",
     highlightClass: options.highlightClass || "content-highlight",
     highlightIdentifyClassRoot: options.highlightIdentifyClassRoot || "content-highlight-identifier-",
@@ -63,7 +64,11 @@ var contentHighlightWorker = function(element, options){
     rangy.init();
     this.getContentHighlightsFromServer();
     if (!this.settings.readOnly) {
-      element.addEventListener('mouseup', this.showPopTipForSelection);
+      if (this.settings.confirmHighlight) {
+        element.addEventListener('mouseup', this.showPopTipForSelection);
+      } else {
+        element.addEventListener('mouseup', this.initializeHighlighter);
+      }
     }
   }
 

--- a/vendor/assets/stylesheets/content_highlight.css
+++ b/vendor/assets/stylesheets/content_highlight.css
@@ -31,7 +31,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.content-highlight-poptip .cancel_highlight{
+.content-highlight-poptip .poptip-action{
   font-size: 80%;
   text-decoration: underline;
   color: inherit;


### PR DESCRIPTION
Allows for copying/selection of text without adding highlight. Initialization param: confirmHighlight

Poptip methods are a bit repetitive, but figured the extrapolation would end up being more verbose and decided against it.

